### PR TITLE
added add,del & delAll methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@
 
 'use strict';
 
-var kafka = require('kafka-node-slim'),
+var kafka = require('kafka-node'),
     Adapter = require('socket.io-adapter'),
     debug = require('debug')('socket.io-kafka'),
     async = require('async'),

--- a/index.js
+++ b/index.js
@@ -46,14 +46,14 @@ function adapter(uri, options) {
 
     // create producer and consumer if they weren't provided
     if (!opts.producer || !opts.consumer) {
-       // debug('creating new kafa client');
+        debug('creating new kafa client');
         client = new kafka.Client(uri, opts.clientId, { retries: 2 });
         if (!opts.producer) {
-          //  debug('creating new kafa producer');
+            debug('creating new kafa producer');
             opts.producer = new kafka.Producer(client);
         }
         if (!opts.consumer) {
-          //  debug('creating new kafa consumer');
+            debug('creating new kafa consumer');
             opts.consumer = new kafka.Consumer(client, [], { groupId: prefix });
         }
     }
@@ -79,7 +79,7 @@ function adapter(uri, options) {
         opts.createTopics = (create === undefined) ? true : create;
 
         opts.producer.on('ready', function () {
-            //debug('producer ready');
+            debug('producer ready');
             self.createTopic(self.mainTopic, function (err, data) {
                 if (!err) {
                     self.subscribe(self.mainTopic);
@@ -253,17 +253,19 @@ function adapter(uri, options) {
         var self = this,
             channel;
 
-        debug('broadcasting packet', packet, opts);
+        
         Adapter.prototype.broadcast.call(this, packet, opts);
 
         if (!remote) {
             if (opts.rooms) {
                 opts.rooms.forEach(function (room) {
                     channel = self.safeTopicName(self.mainTopic) + room;
+                    debug('broadcasting to %s',channel);
                     self.publish(channel, packet, opts);
                 });
             } else {
                 channel = self.safeTopicName(self.mainTopic);
+                debug('broadcasting to %s',channel);
                 self.publish(channel, packet, opts);
             }
         }
@@ -291,7 +293,6 @@ function adapter(uri, options) {
         this.rooms[room][id] = true;
         channel = self.safeTopicName(self.mainTopic) + room;
 
-        debug('topic: %s, uid: %s', channel, this.uid);
         /** create the topic as producer and subscribe as a consumer */
         self.createTopic(channel, function (err, data) {
             if (!err) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.1.3",
-    "kafka-node-slim": "^0.1.0",
+    "kafka-node": "git://github.com/azriel46d/kafka-node.git",
     "socket.io-adapter": "^0.3.1",
     "uid2": "0.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.1.3",
-    "kafka-node": "^0.2.24",
+    "kafka-node-slim": "^0.1.0",
     "socket.io-adapter": "^0.3.1",
     "uid2": "0.0.3"
   },


### PR DESCRIPTION
based on the socket.io-adapter I've added the add , del  & delAll methods and adjusted the broadcast method. 

I'm using kafka-node-slim instead of kafka-node as unfortunately snappy was not building with node-gyp on windows. It makes it easier with the cut down version to move between platforms.
